### PR TITLE
Update inc_bonuses.nss

### DIFF
--- a/scripts/inc_bonuses.nss
+++ b/scripts/inc_bonuses.nss
@@ -239,8 +239,8 @@ void ApplyCharacterBonuses(object oPC, int bReapplySpecialAbilities = FALSE, int
     // reported move speed bugs.
     DelayCommand(1.0, ApplyEffectToObject(DURATION_TYPE_TEMPORARY, EffectMovementSpeedDecrease(1), oPC, 0.1));
 
-    // Restrict monk AC bonus to monks that have 6+ monk levels. 
-    if (GetKnowsFeat(FEAT_MONK_AC_BONUS ,oPC) && GetLevelByClass(CLASS_TYPE_MONK, oPC) < 6 && GetHitDice(oPC) > GetLevelByClass(CLASS_TYPE_MONK, oPC)) NWNX_Creature_RemoveFeat(oPC, FEAT_MONK_AC_BONUS);
+    // Restrict monk AC bonus to monks that have 6+ monk levels or majority monk levels(to aid low levels).
+    if (GetKnowsFeat(FEAT_MONK_AC_BONUS ,oPC) && GetLevelByClass(CLASS_TYPE_MONK, oPC) < 6 && (GetCharacterLevel(oPC) - GetLevelByClass(CLASS_TYPE_MONK, oPC)) > GetLevelByClass(CLASS_TYPE_MONK, oPC)) NWNX_Creature_RemoveFeat(oPC, FEAT_MONK_AC_BONUS);
 
     // Restore monk AC bonus to characters it was wrongly taken from
     if (GetLevelByClass(CLASS_TYPE_MONK, oPC) >= 6 && !GetKnowsFeat(FEAT_MONK_AC_BONUS ,oPC)) AddKnownFeat(oPC, FEAT_MONK_AC_BONUS);


### PR DESCRIPTION
Change to Monk AC to apply to 6+ monk levels as well as majority monk levels, to allow low level monks to multi class before their 6th monk level.